### PR TITLE
Build locally

### DIFF
--- a/requirements-pipeline.txt
+++ b/requirements-pipeline.txt
@@ -1,2 +1,3 @@
 jupyter==1.0.0
+jupyter_contrib_nbextensions==0.5.1
 nb-filter-cells==0.0.2

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "gatsby-starter-default",
+  "name": "cdei-bias-website",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
Some very small changes arising from me building locally

1. I needed `jupyter_contrib_nbextensions` installed, so added it to pipeline requirements.
2. `package-lock.json` hadn't been committed since the name was changed. This is an auto-generated change.