### PR TITLE
Fix workflow trigger events

### DIFF
--- a/.github/workflows/notebook-deploy.yml
+++ b/.github/workflows/notebook-deploy.yml
@@ -2,8 +2,8 @@ name: Clean and Release Notebooks
 
 on:
   push:
-    branch:
-      - 'master'
+    branches:
+      - master
 
 jobs:
   clean-notebook:

--- a/.github/workflows/site-deploy.yml
+++ b/.github/workflows/site-deploy.yml
@@ -2,8 +2,8 @@ name: Build and Deploy Site
 
 on:
   push:
-    branch:
-      - 'master'
+    branches:
+      - master
 
 jobs:
   deploy:
@@ -50,4 +50,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: site/public
-


### PR DESCRIPTION
Only trigger workflows on master branch, there was a typo in the specification: `branch` -> `branches`

[Documentation reference](https://help.github.com/en/actions/reference/events-that-trigger-workflows#example-using-multiple-events-with-activity-types-or-configuration)