### PR TITLE
more styling to hide narrow plots and enabling formatting of CSS files

### DIFF
--- a/src/site/gatsby-browser.js
+++ b/src/site/gatsby-browser.js
@@ -1,0 +1,1 @@
+import "./src/styles/global.css"

--- a/src/site/package.json
+++ b/src/site/package.json
@@ -34,8 +34,8 @@
   "scripts": {
     "build": "gatsby build --prefix-paths",
     "develop": "gatsby develop",
-    "format": "prettier --write \"**/*.{js,jsx,md,mdx}\"",
-    "format-check": "prettier --check \"**/*.{js,jsx,md,mdx}\"",
+    "format": "prettier --write \"**/*.{css,js,jsx,md,mdx}\"",
+    "format-check": "prettier --check \"**/*.{css,js,jsx,md,mdx}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean"

--- a/src/site/src/components/accordion.css
+++ b/src/site/src/components/accordion.css
@@ -4,51 +4,51 @@
 * ----------------------------------------------
 **/
 .accordion {
-    border: 1px solid rgba(0, 0, 0, 0.1);
-    border-radius: 2px;
-    margin-top: 1em;
-    margin-bottom: 1em;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 2px;
+  margin-top: 1em;
+  margin-bottom: 1em;
 }
 
 .accordion__item + .accordion__item {
-    border-top: 1px solid rgba(0, 0, 0, 0.1);
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 .accordion__button {
-    background-color: #eee;
-    color: #444;
-    cursor: pointer;
-    padding: 18px;
-    width: 100%;
-    text-align: left;
-    border: none;
+  background-color: #eee;
+  color: #444;
+  cursor: pointer;
+  padding: 18px;
+  width: 100%;
+  text-align: left;
+  border: none;
 }
 
 .accordion__button:hover {
-    background-color: #ddd;
+  background-color: #ddd;
 }
 
 .accordion__button:before {
-    display: inline-block;
-    content: '';
-    height: 10px;
-    width: 10px;
-    margin-right: 12px;
-    border-bottom: 2px solid currentColor;
-    border-right: 2px solid currentColor;
-    transform: rotate(-45deg);
-    transition: transform 0.3s ease;
+  display: inline-block;
+  content: "";
+  height: 10px;
+  width: 10px;
+  margin-right: 12px;
+  border-bottom: 2px solid currentColor;
+  border-right: 2px solid currentColor;
+  transform: rotate(-45deg);
+  transition: transform 0.3s ease;
 }
 
-.accordion__button[aria-expanded='true']::before,
-.accordion__button[aria-selected='true']::before {
-    transform: rotate(45deg);
-    transition: transform 0.3s ease;
+.accordion__button[aria-expanded="true"]::before,
+.accordion__button[aria-selected="true"]::before {
+  transform: rotate(45deg);
+  transition: transform 0.3s ease;
 }
 
 .accordion__panel {
-    padding: 1em 2em 0.5em 2em;
-    animation: fadein 0.3s ease-in;
+  padding: 1em 2em 0.5em 2em;
+  animation: fadein 0.3s ease-in;
 }
 
 /* -------------------------------------------------- */
@@ -56,11 +56,11 @@
 /* -------------------------------------------------- */
 
 @keyframes fadein {
-    0% {
-        opacity: 0;
-    }
+  0% {
+    opacity: 0;
+  }
 
-    100% {
-        opacity: 1;
-    }
+  100% {
+    opacity: 1;
+  }
 }

--- a/src/site/src/components/siteplotly.js
+++ b/src/site/src/components/siteplotly.js
@@ -1,6 +1,7 @@
 import React from "react"
 import Loadable from "react-loadable"
 import Loader from "react-loader-spinner"
+import { MdAspectRatio } from "react-icons/md"
 
 const spinnerStyle = { textAlign: "center" }
 
@@ -24,24 +25,30 @@ const Plotly = Loadable({
 })
 
 export const LazyPlot = ({ ...rest }) => (
-  <Plotly
-    layout={{
-      margin: { t: 0, r: 0, l: 35 },
-      paper_bgcolor: `rgba(0, 0, 0, 0)`,
-      plot_bgcolor: `rgba(0, 0, 0, 0)`,
-      font: {
-        color: `black`,
-        size: 16,
-      },
-      // The next 3 directives make the plot responsive.
-      autosize: true,
-    }}
-    style={{ width: `100%` }}
-    useResizeHandler
-    config={{
-      displayModeBar: false,
-      showTips: false,
-    }}
-    {...rest}
-  />
+  <div>
+    <Plotly
+      layout={{
+        margin: { t: 0, r: 0, l: 35 },
+        paper_bgcolor: `rgba(0, 0, 0, 0)`,
+        plot_bgcolor: `rgba(0, 0, 0, 0)`,
+        font: {
+          color: `black`,
+          size: 16,
+        },
+        // The next 3 directives make the plot responsive.
+        autosize: true,
+      }}
+      style={{ width: `100%` }}
+      useResizeHandler
+      config={{
+        displayModeBar: false,
+        showTips: false,
+      }}
+      {...rest}
+    />
+    <div class="narrow-screen-warning">
+      <MdAspectRatio /> Your screen is too narrow to display a plot. Please try
+      a bigger screen, or landscape mode.
+    </div>
+  </div>
 )

--- a/src/site/src/styles/global.css
+++ b/src/site/src/styles/global.css
@@ -1,0 +1,19 @@
+code.inline-code {
+  /* Overriding the theme style, hence the "!important" */
+  background-color: #888 !important;
+}
+
+.narrow-screen-warning {
+  display: none;
+}
+
+@media screen and (max-width: 600px) {
+  /* Hide plots and show warning. */
+  .js-plotly-plot {
+    display: none;
+  }
+  .narrow-screen-warning {
+    display: block;
+    padding: 1em;
+  }
+}


### PR DESCRIPTION
Milder gray for code block:

<img width="360" alt="Screenshot 2020-06-23 16 00 26" src="https://user-images.githubusercontent.com/38863/85420058-a81f3600-b56a-11ea-8d76-7456bf4667f0.png">

Hiding plots on screens with <600px width:

<img width="455" alt="Screenshot 2020-06-23 16 01 26" src="https://user-images.githubusercontent.com/38863/85420226-d43ab700-b56a-11ea-8ace-67c1f6c5e1ab.png">

Wording could definitely use some tweaking.