### PR TITLE
disable plotly resize handler to keep better plot sizes

### DIFF
--- a/src/site/src/components/siteplotly.js
+++ b/src/site/src/components/siteplotly.js
@@ -30,7 +30,7 @@ export const LazyPlot = ({ ...rest }) => (
         autosize: true,
       }}
       style={{ width: `100%` }}
-      useResizeHandler
+      useResizeHandler={false}
       config={{
         displayModeBar: false,
         showTips: false,


### PR DESCRIPTION
It's not ideal as it would be better to enable it to make plots
responsive, but the current setting basically messes up
the plot sizes whenever I navigate away from the page then
come back.

Testing to see if this works better. Need to keep an eye
on phone portrait/landscape switches as corner case.

Connects-to: #102 
Signed-off-by: Gergely Imreh <gergely.imreh@faculty.ai>