### PR TITLE
center plotly images

### DIFF
--- a/src/helpers/helpers/plot.py
+++ b/src/helpers/helpers/plot.py
@@ -119,6 +119,11 @@ def group_bar_plots(
                     scores[(attr == a) & (groups == group)].mean()
                     for group in unique_groups
                 ],
+                marker={
+                    "color": _hex_to_rgba(COLORS[i], 0.5),
+                    "line_color": COLORS[i],
+                    "line_width": 1,
+                },
                 y=unique_groups,
                 name=a,
                 orientation="h",

--- a/src/helpers/helpers/plot.py
+++ b/src/helpers/helpers/plot.py
@@ -129,7 +129,7 @@ def group_bar_plots(
                 orientation="h",
                 hoverinfo="name+x",
             )
-            for a in sorted(set(attr))
+            for i, a in enumerate(sorted(set(attr)))
         ],
         layout={
             "autosize": True,

--- a/src/site/src/styles/global.css
+++ b/src/site/src/styles/global.css
@@ -7,6 +7,10 @@ code.inline-code {
   display: none;
 }
 
+.js-plotly-plot > .plot-container > div.svg-container {
+  margin: 0 auto !important;
+}
+
 @media screen and (max-width: 600px) {
   /* Hide plots and show warning. */
   .js-plotly-plot {


### PR DESCRIPTION
## Center Plotly images

Since we don't resize at the moment things can look weird when on a larger screen (left justified). With this we can center things, until responsive images are fixed.

I didn't see it before seeing it in a presentation how things might look right now.

Before:

<img width="911" alt="Screenshot 2020-06-24 13 59 30" src="https://user-images.githubusercontent.com/38863/85561206-48389600-b623-11ea-8b78-0360bc0a327f.png">

After:

<img width="913" alt="Screenshot 2020-06-24 14 01 54" src="https://user-images.githubusercontent.com/38863/85561243-4e2e7700-b623-11ea-87b4-edbe47622bb2.png">


## Bar chart plot colours

Make the bar charts' colours softer, similar to the box plots

Before: as above

After:

<img width="614" alt="Screenshot 2020-06-24 14 04 31" src="https://user-images.githubusercontent.com/38863/85561592-a1a0c500-b623-11ea-8529-2cea721cc5d3.png">


