### PR TITLE
Use fetch to get json data

### DIFF
--- a/src/site/src/components/siteplotly.js
+++ b/src/site/src/components/siteplotly.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react"
+import { withPrefix } from "gatsby"
 import Loadable from "react-loadable"
 import { MdAspectRatio } from "react-icons/md"
 
@@ -51,14 +52,8 @@ export function PlotLoader({ source }) {
     let mounted = true
 
     const getData = async () => {
-      const data = await import(
-        /* webpackInclude: /\.json$/ */
-        /* webpackChunkName: "figure" */
-        /* webpackMode: "lazy" */
-        /* webpackPrefetch: true */
-        /* webpackPreload: true */
-        `./../../static/figures/${source}.json`
-      )
+      const response = await fetch(withPrefix(`/figures/${source}.json`))
+      const data = await response.json()
       // Workaround for badly resized plots
       data.layout.autosize = false
 


### PR DESCRIPTION
When I was preparing for the demo I noticed that navigation between pages was super laggy, seems to be loading way more than we want before the first render.

This PR swaps out the dynamic import for a fetch call. Performance benefits are not super obvious on a development server, but I found `npm run build && npm run serve` showed a good improvement, navigation between pages is much faster, though the downside is that the PACE bar no longer corresponds to loading of the figures (but that is still covered by the loading dots at least).

Would be interested to hear your thoughts. (Also need to check the preview deployment to see if the improvements I think I observed locally are preserved on the deployed site).