### PR TITLE
fix page bottom navigation & other fine tuning

### DIFF
--- a/src/site/src/@rocketseat/gatsby-theme-docs/text/index.mdx
+++ b/src/site/src/@rocketseat/gatsby-theme-docs/text/index.mdx
@@ -6,7 +6,7 @@ Our goal is to both demonstrate how such interventions can be carried out, and t
 
 All of our analysis is available in the form of [Jupyter notebooks][jupyter] which can be run in the browser on [Binder][binder], or run locally by cloning from the accompanying [GitHub repository][github]. The supplied notebooks can be used to regenerate the data and retrain the models, but for full reproducibility we also include our trained models and processed data in the repository. We hope that by making our analysis available we not only help demonstrate how these tools and techniques can be adopted, but we also allow for improvements to our analysis to be submitted in the form of pull requests, so that our examples benefit from the input of many experts and stakeholders.
 
-We will start be introducing the two data sets that will be used throughout to compare the different interventions.
+We will start be introducing the two data sets that will be used throughout to compare the different interventions, the first data set for [finance](finance), the second for [recruiting](recruiting).
 
 [binder]: https://mybinder.org/v2/gh/imrehg/cdei-development/master?filepath=notebooks "Open notebooks on Binder"
 [github]: https://github.com/imrehg/cdei-development

--- a/src/site/src/components/siteplotly.js
+++ b/src/site/src/components/siteplotly.js
@@ -9,7 +9,9 @@ const Plotly = Loadable({
   loader: () => import(`react-plotly.js`),
   loading: ({ timedOut }) =>
     timedOut ? (
-      <blockquote>Error: Loading Plotly timed out. Please try to refresh the page!</blockquote>
+      <blockquote>
+        Error: Loading Plotly timed out. Please try to refresh the page!
+      </blockquote>
     ) : (
       <Loading />
     ),

--- a/src/site/src/components/siteplotly.js
+++ b/src/site/src/components/siteplotly.js
@@ -9,11 +9,11 @@ const Plotly = Loadable({
   loader: () => import(`react-plotly.js`),
   loading: ({ timedOut }) =>
     timedOut ? (
-      <blockquote>Error: Loading Plotly timed out.</blockquote>
+      <blockquote>Error: Loading Plotly timed out. Please try to refresh the page!</blockquote>
     ) : (
       <Loading />
     ),
-  timeout: 10000,
+  timeout: 15000,
 })
 
 export const LazyPlot = ({ ...rest }) => (

--- a/src/site/src/config/sidebar.yml
+++ b/src/site/src/config/sidebar.yml
@@ -4,18 +4,18 @@
 - label: Use Cases
   items:
     - label: Finance
-      link: /finance/
+      link: /finance
     - label: Recruiting
-      link: /recruiting/
+      link: /recruiting
 - label: Modelling
   items:
     - label: Unfair Baseline
-      link: /baseline/
+      link: /baseline
     - label: Interventions
-      link: /interventions/
+      link: /interventions
 - label: Summary
   items:
     - label: Conclusions
-      link: /conclusions/
+      link: /conclusions
     - label: Additional Resources
-      link: /additional-resources/
+      link: /additional-resources


### PR DESCRIPTION
Trailing slashes in the navigation menu (sidebar) broke the bottom page navigation. Everywhere it just had a link back Home, and nothing else. Removing the slashes it seems to correctly recognise the pages and link to them.